### PR TITLE
Added a margin to terms and privacy pages

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -446,7 +446,7 @@ li {
   }
 }
 
-.termsAndPrivacyBody {
+.custom-text-container {
   margin: 2%;
 }
 

--- a/src/components/CustomTextContainer.js
+++ b/src/components/CustomTextContainer.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default ({ children }) => (
+  <div className="custom-text-container">{children}</div>
+);

--- a/src/components/PrivacyPolicy.js
+++ b/src/components/PrivacyPolicy.js
@@ -1,8 +1,9 @@
 import React from "react";
+import CustomTextContainer from "./CustomTextContainer";
 
 export function PrivacyPolicy() {
   return (
-    <body className="termsAndPrivacyBody">
+    <CustomTextContainer>
       <strong>Privacy Policy</strong>
       <p>
         Codelet LLC built the Codelet app as a Freemium app. This SERVICE is
@@ -169,6 +170,6 @@ export function PrivacyPolicy() {
           App Privacy Policy Generator
         </a>
       </p>
-    </body>
+    </CustomTextContainer>
   );
 }

--- a/src/components/Terms.js
+++ b/src/components/Terms.js
@@ -1,8 +1,9 @@
 import React from "react";
+import CustomTextContainer from "./CustomTextContainer";
 
 export function Terms() {
   return (
-    <body className="termsAndPrivacyBody">
+    <CustomTextContainer>
       <strong>Terms &amp; Conditions</strong>
       <p>
         By downloading or using the app, these terms will automatically apply to
@@ -133,6 +134,6 @@ export function Terms() {
           App Privacy Policy Generator
         </a>
       </p>
-    </body>
+    </CustomTextContainer>
   );
 }


### PR DESCRIPTION
### Issues
<!-- Refer to a specific issues-->
This hotfix adds a margin to the terms and privacy pages

### Help!
<!-- Asking for help! Make sure to give good Pull Request overview -->
Should I delete the `_redirects` file inside the main directory too while I'm making this hotfix?  It sounds like that one is unnecessary and the one that actually works/we actually need is the one in the public folder.