### PR TITLE
Reset Question Submission Form Upon Successful Submit

### DIFF
--- a/src/components/CustomHooks/useEditQuestion.js
+++ b/src/components/CustomHooks/useEditQuestion.js
@@ -4,12 +4,8 @@ import { string } from "prop-types";
 import { apiRequest, getEnvUrl } from "../../services";
 
 export const useEditQuestion = (question) => {
-  let submitUrl = `questions/number/${question.questionNumber}`;
-
-  const form = useForm();
-
-  const { register, control, handleSubmit, errors, reset, ...rest } = form;
-
+  const submitUrl = `questions/number/${question.questionNumber}`;
+  const { register, control, handleSubmit, errors, reset, ...rest } = useForm();
   const [submitError, setSubmitError] = useState("");
 
   useEffect(() => {

--- a/src/components/CustomHooks/useSubmitQuestion.js
+++ b/src/components/CustomHooks/useSubmitQuestion.js
@@ -3,8 +3,8 @@ import { useForm } from "react-hook-form";
 import { apiRequest, getEnvUrl } from "../../services";
 
 export const useSubmitQuestion = () => {
-  let submitUrl = "questions/post-question";
-  const { register, control, handleSubmit, errors, ...rest } = useForm();
+  const submitUrl = "questions/post-question";
+  const { register, control, handleSubmit, errors, reset, ...rest } = useForm();
   const [submitError, setSubmitError] = useState("");
 
   const onSubmit = async (data) => {
@@ -67,7 +67,8 @@ export const useSubmitQuestion = () => {
         solution,
       },
     });
-    if (response.status >= 200 && response.status < 300) {
+    if (response.status === 201) {
+      reset();
       window.location.assign("/submit-question/thanks");
     } else {
       setSubmitError(response.data.message);


### PR DESCRIPTION
### Related Issues
closes #30 

### Description of Changes
- Added call to `reset()` the form upon successful submission before redirecting the user to the thank you page